### PR TITLE
bug fixed for android with ms-outlook client and HTML content

### DIFF
--- a/src/android/EmailComposer.java
+++ b/src/android/EmailComposer.java
@@ -195,7 +195,7 @@ public class EmailComposer extends CordovaPlugin {
             draft.setType("text/html");
 
             if (Build.VERSION.SDK_INT > 15) {
-                draft.putExtra(Intent.EXTRA_HTML_TEXT, body);
+                draft.putExtra(Intent.EXTRA_HTML_TEXT, Html.fromHtml(body));
             }
         } else {
             draft.putExtra(Intent.EXTRA_TEXT, body);


### PR DESCRIPTION
When i tried to send an email with args:

``` json
{
    body: "<p>Some text</p>",
    isHtml: true
}
```

with MsOutlook on Android (5.1) device the content of the email was in plain text and contained the html tags.
Now the ms client interprets the text like HTML.
