### PR TITLE
[iOS]Add support for Cordova 4.x.

### DIFF
--- a/src/ios/APPEmailComposer.m
+++ b/src/ios/APPEmailComposer.m
@@ -20,9 +20,9 @@
  */
 
 #import "APPEmailComposer.h"
-#import "Cordova/NSData+Base64.h"
 #import "Cordova/CDVAvailability.h"
 #import <MobileCoreServices/MobileCoreServices.h>
+#import <objc/message.h>
 
 #include "TargetConditionals.h"
 
@@ -446,7 +446,23 @@
                                                    range:NSMakeRange(0, length)
                                             withTemplate:@""];
 
-    NSData* data = [NSData dataFromBase64String:dataString];
+    NSData *data;
+    SEL initWithBase64EncodedStringOptionsSEL = @selector(initWithBase64EncodedString:options:);
+    SEL initWithBase64EncodingSEL = @selector(initWithBase64Encoding:);
+
+    // NSData+Base64.h has been removed in Cordova 4.x
+    // Plugin authors are encouraged to use the (iOS 7+) base64 encoding and decoding
+    // methods available in NSData instead.
+    // See for more details:
+    // https://github.com/apache/cordova-ios/blob/master/guides/API%20changes%20in%204.0.md
+
+    if ([NSData instancesRespondToSelector:initWithBase64EncodedStringOptionsSEL]) {
+        // iOS 7.x + support.
+        data = objc_msgSend(NSData.alloc, initWithBase64EncodedStringOptionsSEL, dataString, kNilOptions);
+    } else if ([NSData instancesRespondToSelector:initWithBase64EncodingSEL]) {
+        // iOS 6.x support
+        data = objc_msgSend(NSData.alloc, initWithBase64EncodingSEL, dataString);
+    }
 
     return data;
 }


### PR DESCRIPTION
**Description:**
Fix compiler error when building AB project (using Cordova v4.x or later) with latest plugin (v0.8.2.2).

> NSData+Base64.h has been removed in Cordova 4.x
> Plugin authors are encouraged to use the (iOS 7+) base64 encoding and decoding methods available in NSData instead.
> See [API Changes in cordova-ios-4.0](https://github.com/apache/cordova-ios/blob/master/guides/API%20changes%20in%204.0.md) for more details regarding API changes.

**TeamPulse:** [[Plugins][iOS] iOS Build for Cordova 5.0 fails with Telerik Analytics plugin](http://teampulse.telerik.com/view#item/315412)
**Tests Report:** [MarketPluginTests Report](http://ice-qajenkins:8080/view/Samples+Plugins/job/CLI_Build_Marketplace_Combo_Plugins_LIN/138/HTML_Report_and_Logs/)
